### PR TITLE
Print exceptions

### DIFF
--- a/src/krell/main.clj
+++ b/src/krell/main.clj
@@ -7,6 +7,8 @@
 (defn -main [& args]
   (try
     (apply cljs.main/-main (concat ["-re" "krell.repl"] args))
+    (catch Exception e
+      (.printStackTrace e))
     (finally
       ;; TODO: shouldn't need this
       (System/exit 0))))


### PR DESCRIPTION
Perhaps not this particular revision, but something along these lines might be useful.

(I discovered this because I inadvertently ended up with the rebased version of ClojureScript in my  Deps, and things silently failed when trying to start the Krell REPL.)