### PR TITLE
KRELL-71: Multiple reloads

### DIFF
--- a/resources/index.js
+++ b/resources/index.js
@@ -42,7 +42,6 @@ class KrellRoot extends React.Component {
             krell.setState({root: appRoot, loaded: true});
         });
         onKrellReload(() => {
-            console.log("KRELL RELOAD");
             krell.setState((state, props) => {
                 return {
                     loaded: state.loaded,

--- a/resources/krell_repl.js
+++ b/resources/krell_repl.js
@@ -236,6 +236,7 @@ var handleMessage = function(socket, data){
         if (req) {
             notifyListeners(req);
             if(req.reload) {
+                console.log(req);
                 notifyReloadListeners();
             }
         }

--- a/src/krell/util.clj
+++ b/src/krell/util.clj
@@ -57,6 +57,14 @@
     (let [idx (.lastIndexOf path ".")]
       (when (pos? idx) (subs path idx)))))
 
+(defn files-seq [dir]
+  (tree-seq
+    (fn [^File f]
+      (. f (isDirectory)))
+    (fn [^File d]
+      (seq (. d (listFiles))))
+    dir))
+
 (defn mkdirs
   "Create all parent directories for the passed file."
   [^File f]


### PR DESCRIPTION
construct an index of the watched files to filter :create events from
the watcher.

Log reloads.

Fixes #71