### PR TITLE
Support running multiple instances of the same application

### DIFF
--- a/resources/krell_repl.js
+++ b/resources/krell_repl.js
@@ -1,5 +1,7 @@
 import { Platform } from "react-native";
 import TcpSocket from "react-native-tcp-socket";
+import DeviceInfo from "react-native-device-info";
+import { krellPortMap } from '../app.json';
 import {
     bootstrapRepl,
     evaluate,
@@ -11,11 +13,13 @@ var CONNECTED = false;
 var RECONNECT_INTERVAL = 3000;
 
 var SERVER_IP = "$KRELL_SERVER_IP";
-var SERVER_PORT = $KRELL_SERVER_PORT;
+var SERVER_PORT = krellPortMap ? krellPortMap[DeviceInfo.getDeviceId()] : $KRELL_SERVER_PORT;
 
 const KRELL_VERBOSE = $KRELL_VERBOSE;
 
 var reloadListeners = [];
+
+console.log("Krell sez howdy, Device ID:", DeviceInfo.getDeviceId());
 
 // =============================================================================
 // REPL Server

--- a/src/deps.cljs
+++ b/src/deps.cljs
@@ -1,1 +1,2 @@
-{:npm-deps {"react-native-tcp-socket" "5.2.0"}}
+{:npm-deps {"react-native-tcp-socket" "5.2.0"
+            "react-native-device-info" "8.1.2"}}


### PR DESCRIPTION
add react-native-device-info dep, if provided, use krellPortMap from app.json which maps the device ID to a port.

Log the device ID on startup.

If :recompile is false in Krell, don't watch
the directory or recompile.

Parse port option to integer if string.

Fixes #133 