### PR TITLE
Update README to reflect Expo integration support

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,9 +167,6 @@ please file a Github issue!
   should make it pretty clear how to integrate with any particular ClojureScript 
   React library.
 
-* Basic React Native only, we're not interested in Expo or any other similar
-  tooling
-
 ## License ##
 
     Copyright (c) Vouch, Inc. All rights reserved. The use and


### PR DESCRIPTION
Hello! It looks like now you provide a way to integrate with Expo, so this design principle doesn't appear to apply anymore.